### PR TITLE
Fix NoSuchMethodError on newer versions of PowerRanks

### DIFF
--- a/powerranks/build.gradle
+++ b/powerranks/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile project(':common')
     compileOnly 'org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT'
 
-    compileOnly('nl.svenar:powerranks:1.9.2') {
+    compileOnly('nl.svenar:powerranks:1.9.9') {
         exclude(module: 'nametagedit')
     }
 }

--- a/powerranks/src/main/java/me/lucko/luckperms/migration/MigrationPowerRanks.java
+++ b/powerranks/src/main/java/me/lucko/luckperms/migration/MigrationPowerRanks.java
@@ -32,7 +32,6 @@ import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.types.InheritanceNode;
 
 import nl.svenar.PowerRanks.Cache.CachedPlayers;
-import nl.svenar.PowerRanks.Cache.PowerConfigurationSection;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.api.PowerRanksAPI;
@@ -40,6 +39,7 @@ import nl.svenar.PowerRanks.api.PowerRanksAPI;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Set;
@@ -106,7 +106,7 @@ public final class MigrationPowerRanks extends JavaPlugin {
 
             user.data().add(InheritanceNode.builder(CachedPlayers.getString("players." + uuidString + ".rank")).build());
 
-            final PowerConfigurationSection subGroups = CachedPlayers.getConfigurationSection("players." + uuidString + ".subranks");
+            final ConfigurationSection subGroups = CachedPlayers.getConfigurationSection("players." + uuidString + ".subranks");
             if (subGroups != null) {
                 for (String subGroup : subGroups.getKeys(false)) {
                     InheritanceNode.Builder builder = InheritanceNode.builder(subGroup);


### PR DESCRIPTION
A recent(-ish) patch in PowerRanks ended up in the [deletion of the `PowerConfigurationSection`](https://github.com/svenar-nl/PowerRanks/commit/f3d865631f3634cb28a237b8d86ff335fa98b176#diff-975d99ce69f78905ea5d11e708f266dc3ffd1fa9b6cd2cfc66c65981c44f9f60) causing a `NoSuchMethodError` to be thrown at runtime. This was [replaced with Bukkit's `ConfigurationSection`](https://github.com/svenar-nl/PowerRanks/commit/f3d865631f3634cb28a237b8d86ff335fa98b176#diff-975d99ce69f78905ea5d11e708f266dc3ffd1fa9b6cd2cfc66c65981c44f9f60)

**Untested**, although it should work fine.